### PR TITLE
bpo-67790: Add float-style formatting for Fraction objects

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -194,15 +194,15 @@ another rational number, or from a string.
 
    .. method:: __format__(format_spec, /)
 
-      This method provides support for float-style formatting of
-      :class:`Fraction` instances via the :meth:`str.format` method, the
-      :func:`format` built-in function, or :ref:`Formatted string literals
-      <f-strings>`. The presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``,
-      ``"g"``, ``"G"`` and ``"%"`` are supported. For these presentation types,
-      formatting for a :class:`Fraction` object ``x`` behaves as though the
-      object ``x`` were first converted to :class:`float` and then formatted
-      using the float formatting rules, but avoids the loss of precision that
-      might arise as a result of that conversion.
+      Provides support for float-style formatting of :class:`Fraction`
+      instances via the :meth:`str.format` method, the :func:`format` built-in
+      function, or :ref:`Formatted string literals <f-strings>`. The
+      presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``, ``"G"``
+      and ``"%"`` are supported. For these presentation types, formatting for a
+      :class:`Fraction` object ``x`` behaves as though the object ``x`` were
+      first converted to :class:`float` and then formatted using the float
+      formatting rules, but avoids the loss of precision that might arise as a
+      result of that conversion.
 
       Here are some examples::
 

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -199,8 +199,8 @@ another rational number, or from a string.
       :func:`format` built-in function, or :ref:`Formatted string literals
       <f-strings>`. The presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``,
       ``"g"``, ``"G"`` and ``"%"`` are supported. For these presentation types,
-      formatting for a :class:`Fraction` object `x` behaves as though the
-      object `x` were first converted to :class:`float` and then formatted
+      formatting for a :class:`Fraction` object ``x`` behaves as though the
+      object ``x`` were first converted to :class:`float` and then formatted
       using the float formatting rules, but avoids the loss of precision that
       might arise as a result of that conversion.
 

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -103,7 +103,8 @@ another rational number, or from a string.
 
    .. versionchanged:: 3.12
       :class:`Fraction` instances now support float-style formatting, with
-      presentation types `"e"`, `"E"`, `"f"`, `"F"`, `"g"`, `"G"` and `"%""`.
+      presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``, ``"G"``
+      and ``"%""``.
 
    .. attribute:: numerator
 
@@ -196,12 +197,12 @@ another rational number, or from a string.
       This method provides support for float-style formatting of
       :class:`Fraction` instances via the :meth:`str.format` method, the
       :func:`format` built-in function, or :ref:`Formatted string literals
-      <f-strings>`. The presentation types `"e"`, `"E"`, `"f"`, `"F"`, `"g"`,
-      `"G"`` and `"%"` are supported. For these presentation types, formatting
-      for a :class:`Fraction` object `x` behaves as though the object `x` were
-      first converted to :class:`float` and then formatted using the float
-      formatting rules, but avoids the loss of precision that might arise as
-      a result of that conversion.
+      <f-strings>`. The presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``,
+      ``"g"``, ``"G"`` and ``"%"`` are supported. For these presentation types,
+      formatting for a :class:`Fraction` object `x` behaves as though the
+      object `x` were first converted to :class:`float` and then formatted
+      using the float formatting rules, but avoids the loss of precision that
+      might arise as a result of that conversion.
 
       Here are some examples::
 

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -206,16 +206,16 @@ another rational number, or from a string.
 
       Here are some examples::
 
-      >>> from fractions import Fraction
-      >>> format(Fraction(1, 7), '.40g')
-      '0.1428571428571428571428571428571428571429'
-      >>> format(Fraction('1234567.855'), '_.2f')
-      '1_234_567.86'
-      >>> f"{Fraction(355, 113):*>20.6e}"
-      '********3.141593e+00'
-      >>> old_price, new_price = 499, 672
-      >>> "{:.2%} price increase".format(Fraction(new_price, old_price) - 1)
-      '34.67% price increase'
+         >>> from fractions import Fraction
+         >>> format(Fraction(1, 7), '.40g')
+         '0.1428571428571428571428571428571428571429'
+         >>> format(Fraction('1234567.855'), '_.2f')
+         '1_234_567.86'
+         >>> f"{Fraction(355, 113):*>20.6e}"
+         '********3.141593e+00'
+         >>> old_price, new_price = 499, 672
+         >>> "{:.2%} price increase".format(Fraction(new_price, old_price) - 1)
+         '34.67% price increase'
 
 
 .. seealso::

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -101,6 +101,10 @@ another rational number, or from a string.
    .. versionchanged:: 3.12
       Space is allowed around the slash for string inputs: ``Fraction('2 / 3')``.
 
+   .. versionchanged:: 3.12
+      :class:`Fraction` instances now support float-style formatting, with
+      presentation types `"e"`, `"E"`, `"f"`, `"F"`, `"g"`, `"G"` and `"%""`.
+
    .. attribute:: numerator
 
       Numerator of the Fraction in lowest term.
@@ -186,6 +190,31 @@ another rational number, or from a string.
       nearest multiple of ``Fraction(1, 10**ndigits)`` (logically, if
       ``ndigits`` is negative), again rounding half toward even.  This
       method can also be accessed through the :func:`round` function.
+
+   .. method:: __format__(format_spec, /)
+
+      This method provides support for float-style formatting of
+      :class:`Fraction` instances via the :meth:`str.format` method, the
+      :func:`format` built-in function, or :ref:`Formatted string literals
+      <f-strings>`. The presentation types `"e"`, `"E"`, `"f"`, `"F"`, `"g"`,
+      `"G"`` and `"%"` are supported. For these presentation types, formatting
+      for a :class:`Fraction` object `x` behaves as though the object `x` were
+      first converted to :class:`float` and then formatted using the float
+      formatting rules, but avoids the loss of precision that might arise as
+      a result of that conversion.
+
+      Here are some examples::
+
+      >>> from fractions import Fraction
+      >>> format(Fraction(1, 7), '.40g')
+      '0.1428571428571428571428571428571428571429'
+      >>> format(Fraction('1234567.855'), '_.2f')
+      '1_234_567.86'
+      >>> f"{Fraction(355, 113):*>20.6e}"
+      '********3.141593e+00'
+      >>> old_price, new_price = 499, 672
+      >>> "{:.2%} price increase".format(Fraction(new_price, old_price) - 1)
+      '34.67% price increase'
 
 
 .. seealso::

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -199,10 +199,8 @@ another rational number, or from a string.
       function, or :ref:`Formatted string literals <f-strings>`. The
       presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``, ``"G"``
       and ``"%"`` are supported. For these presentation types, formatting for a
-      :class:`Fraction` object ``x`` behaves as though the object ``x`` were
-      first converted to :class:`float` and then formatted using the float
-      formatting rules, but avoids the loss of precision that might arise as a
-      result of that conversion.
+      :class:`Fraction` object ``x`` follows the rules outlined for
+      the :class:`float` type in the :ref:`formatspec` section.
 
       Here are some examples::
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -249,6 +249,12 @@ dis
   :data:`~dis.hasarg` collection instead.
   (Contributed by Irit Katriel in :gh:`94216`.)
 
+fractions
+---------
+
+* Objects of type :class:`fractions.Fraction` now support float-style
+  formatting. (Contributed by Mark Dickinson in :gh:`100161`.)
+
 os
 --
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -324,6 +324,7 @@ class Fraction(numbers.Rational):
                 (?P<align>[<>=^])
             )?
             (?P<sign>[-+ ]?)
+            (?P<no_neg_zero>z)?
             (?P<alt>\#)?
             (?P<zeropad>0(?=\d))?
             (?P<minimumwidth>\d+)?
@@ -350,6 +351,7 @@ class Fraction(numbers.Rational):
             fill = match["fill"] or " "
             align = match["align"] or ">"
             pos_sign = "" if match["sign"] == "-" else match["sign"]
+            neg_zero_ok = not match["no_neg_zero"]
             alternate_form = bool(match["alt"])
             zeropad = bool(match["zeropad"])
             minimumwidth = int(match["minimumwidth"] or "0")
@@ -360,15 +362,15 @@ class Fraction(numbers.Rational):
         # Get sign and output digits for the target number
         negative = self < 0
         shift = precision + 2 if specifier_type == "%" else precision
-        digits = str(round(abs(self) * 10**shift))
+        significand = round(abs(self) * 10**shift)
 
         # Assemble the output: before padding, it has the form
         # f"{sign}{leading}{trailing}", where `leading` includes thousands
         # separators if necessary, and `trailing` includes the decimal
         # separator where appropriate.
-        digits = digits.zfill(precision + 1)
+        digits = str(significand).zfill(precision + 1)
         dot_pos = len(digits) - precision
-        sign = "-" if negative else pos_sign
+        sign = "-" if negative and (significand or neg_zero_ok) else pos_sign
         separator = "." if precision or alternate_form else ""
         percent = "%" if specifier_type == "%" else ""
         trailing = separator + digits[dot_pos:] + percent

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -891,7 +891,7 @@ class FractionTest(unittest.TestCase):
             # Thousands separators
             (F('1234567.123456'), ',.5e', '1.23457e+06'),
             (F('123.123456'), '012_.2e', '0_001.23e+02'),
-            # z flag is legal, but never makes a different to the output
+            # z flag is legal, but never makes a difference to the output
             (F(-1, 7**100), 'z.6e', '-3.091690e-85'),
         ]
         for fraction, spec, expected in testcases:

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -947,12 +947,23 @@ class FractionTest(unittest.TestCase):
             (F(-2, 3), ' .2f', '-0.67'),
             # Formatting to zero places
             (F(1, 2), '.0f', '0'),
+            (F(-1, 2), '.0f', '-0'),
             (F(22, 7), '.0f', '3'),
             (F(-22, 7), '.0f', '-3'),
             # Formatting to zero places, alternate form
             (F(1, 2), '#.0f', '0.'),
+            (F(-1, 2), '#.0f', '-0.'),
             (F(22, 7), '#.0f', '3.'),
             (F(-22, 7), '#.0f', '-3.'),
+            # z flag for suppressing negative zeros
+            (F('-0.001'), 'z.2f', '0.00'),
+            (F('-0.001'), '-z.2f', '0.00'),
+            (F('-0.001'), '+z.2f', '+0.00'),
+            (F('-0.001'), ' z.2f', ' 0.00'),
+            (F('0.001'), 'z.2f', '0.00'),
+            (F('0.001'), '-z.2f', '0.00'),
+            (F('0.001'), '+z.2f', '+0.00'),
+            (F('0.001'), ' z.2f', ' 0.00'),
             # Corner-case: leading zeros are allowed in the precision
             (F(2, 3), '.02f', '0.67'),
             (F(22, 7), '.000f', '3'),
@@ -1040,15 +1051,6 @@ class FractionTest(unittest.TestCase):
             # is being inserted programmatically: spec = f'{width}.2f'.
             (F('12.34'), '0.2f', '12.34'),
             (F('12.34'), 'X>0.2f', '12.34'),
-            # z flag for suppressing negative zeros
-            (F('-0.001'), 'z.2f', '0.00'),
-            (F('-0.001'), '-z.2f', '0.00'),
-            (F('-0.001'), '+z.2f', '+0.00'),
-            (F('-0.001'), ' z.2f', ' 0.00'),
-            (F('0.001'), 'z.2f', '0.00'),
-            (F('0.001'), '-z.2f', '0.00'),
-            (F('0.001'), '+z.2f', '+0.00'),
-            (F('0.001'), ' z.2f', ' 0.00'),
             # "F" should work identically to "f"
             (F(22, 7), '.5F', '3.14286'),
             # %-specifier
@@ -1088,6 +1090,15 @@ class FractionTest(unittest.TestCase):
             (F('9.99999e+2'), '.4g', '1000'),
             (F('9.99999e-8'), '.4g', '1e-07'),
             (F('9.99999e+8'), '.4g', '1e+09'),
+            # Check round-ties-to-even behaviour
+            (F('-0.115'), '.2g', '-0.12'),
+            (F('-0.125'), '.2g', '-0.12'),
+            (F('-0.135'), '.2g', '-0.14'),
+            (F('-0.145'), '.2g', '-0.14'),
+            (F('0.115'), '.2g', '0.12'),
+            (F('0.125'), '.2g', '0.12'),
+            (F('0.135'), '.2g', '0.14'),
+            (F('0.145'), '.2g', '0.14'),
             # Trailing zeros and decimal point suppressed by default ...
             (F(0), '.6g', '0'),
             (F('123.400'), '.6g', '123.4'),

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -888,9 +888,10 @@ class FractionTest(unittest.TestCase):
             (F(22, 7), '11.6e', '3.142857e+00'),
             (F(22, 7), '12.6e', '3.142857e+00'),
             (F(22, 7), '13.6e', ' 3.142857e+00'),
-            # Legal to specify a thousands separator, but it'll have no effect
+            # Thousands separators
             (F('1234567.123456'), ',.5e', '1.23457e+06'),
-            # Same with z flag: legal, but useless
+            (F('123.123456'), '012_.2e', '0_001.23e+02'),
+            # z flag is legal, but never makes a different to the output
             (F(-1, 7**100), 'z.6e', '-3.091690e-85'),
         ]
         for fraction, spec, expected in testcases:

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -976,6 +976,21 @@ class FractionTest(unittest.TestCase):
             # is being inserted programmatically: spec = f'{width}.2f'.
             (F('12.34'), '0.2f', '12.34'),
             (F('12.34'), 'X>0.2f', '12.34'),
+            # "F" should work identically to "f"
+            (F(22, 7), '.5F', '3.14286'),
+            # %-specifier
+            (F(22, 7), '.2%', '314.29%'),
+            (F(1, 7), '.2%', '14.29%'),
+            (F(1, 70), '.2%', '1.43%'),
+            (F(1, 700), '.2%', '0.14%'),
+            (F(1, 7000), '.2%', '0.01%'),
+            (F(1, 70000), '.2%', '0.00%'),
+            (F(1, 7), '.0%', '14%'),
+            (F(1, 7), '#.0%', '14.%'),
+            (F(100, 7), ',.2%', '1,428.57%'),
+            (F(22, 7), '7.2%', '314.29%'),
+            (F(22, 7), '8.2%', ' 314.29%'),
+            (F(22, 7), '08.2%', '0314.29%'),
         ]
         for fraction, spec, expected in testcases:
             with self.subTest(fraction=fraction, spec=spec):

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -840,6 +840,63 @@ class FractionTest(unittest.TestCase):
             with self.subTest(fraction=fraction, spec=spec):
                 self.assertEqual(format(fraction, spec), expected)
 
+    def test_format_e_presentation_type(self):
+        # Triples (fraction, specification, expected_result)
+        testcases = [
+            (F(2, 3), '.6e', '6.666667e-01'),
+            (F(3, 2), '.6e', '1.500000e+00'),
+            (F(2, 13), '.6e', '1.538462e-01'),
+            (F(2, 23), '.6e', '8.695652e-02'),
+            (F(2, 33), '.6e', '6.060606e-02'),
+            (F(13, 2), '.6e', '6.500000e+00'),
+            (F(20, 2), '.6e', '1.000000e+01'),
+            (F(23, 2), '.6e', '1.150000e+01'),
+            (F(33, 2), '.6e', '1.650000e+01'),
+            (F(2, 3), '.6e', '6.666667e-01'),
+            (F(3, 2), '.6e', '1.500000e+00'),
+            # Zero
+            (F(0), '.3e', '0.000e+00'),
+            # Powers of 10, to exercise the log10 boundary logic
+            (F(1, 1000), '.3e', '1.000e-03'),
+            (F(1, 100), '.3e', '1.000e-02'),
+            (F(1, 10), '.3e', '1.000e-01'),
+            (F(1, 1), '.3e', '1.000e+00'),
+            (F(10), '.3e', '1.000e+01'),
+            (F(100), '.3e', '1.000e+02'),
+            (F(1000), '.3e', '1.000e+03'),
+            # Boundary where we round up to the next power of 10
+            (F('99.999994999999'), '.6e', '9.999999e+01'),
+            (F('99.999995'), '.6e', '1.000000e+02'),
+            (F('99.999995000001'), '.6e', '1.000000e+02'),
+            # Negatives
+            (F(-2, 3), '.6e', '-6.666667e-01'),
+            (F(-3, 2), '.6e', '-1.500000e+00'),
+            (F(-100), '.6e', '-1.000000e+02'),
+            # Large and small
+            (F('1e1000'), '.3e', '1.000e+1000'),
+            (F('1e-1000'), '.3e', '1.000e-1000'),
+            # Using 'E' instead of 'e' should give us a capital 'E'
+            (F(2, 3), '.6E', '6.666667E-01'),
+            # Tiny precision
+            (F(2, 3), '.1e', '6.7e-01'),
+            (F('0.995'), '.0e', '1e+00'),
+            # Default precision is 6
+            (F(22, 7), 'e', '3.142857e+00'),
+            # Alternate form forces a decimal point
+            (F('0.995'), '#.0e', '1.e+00'),
+            # Check that padding takes the exponent into account.
+            (F(22, 7), '11.6e', '3.142857e+00'),
+            (F(22, 7), '12.6e', '3.142857e+00'),
+            (F(22, 7), '13.6e', ' 3.142857e+00'),
+            # Legal to specify a thousands separator, but it'll have no effect
+            (F('1234567.123456'), ',.5e', '1.23457e+06'),
+            # Same with z flag: legal, but useless
+            (F(-1, 7**100), 'z.6e', '-3.091690e-85'),
+        ]
+        for fraction, spec, expected in testcases:
+            with self.subTest(fraction=fraction, spec=spec):
+                self.assertEqual(format(fraction, spec), expected)
+
     def test_format_f_presentation_type(self):
         # Triples (fraction, specification, expected_result)
         testcases = [
@@ -1012,58 +1069,60 @@ class FractionTest(unittest.TestCase):
             with self.subTest(fraction=fraction, spec=spec):
                 self.assertEqual(format(fraction, spec), expected)
 
-    def test_format_e_presentation_type(self):
+    def test_format_g_presentation_type(self):
         # Triples (fraction, specification, expected_result)
         testcases = [
-            (F(2, 3), '.6e', '6.666667e-01'),
-            (F(3, 2), '.6e', '1.500000e+00'),
-            (F(2, 13), '.6e', '1.538462e-01'),
-            (F(2, 23), '.6e', '8.695652e-02'),
-            (F(2, 33), '.6e', '6.060606e-02'),
-            (F(13, 2), '.6e', '6.500000e+00'),
-            (F(20, 2), '.6e', '1.000000e+01'),
-            (F(23, 2), '.6e', '1.150000e+01'),
-            (F(33, 2), '.6e', '1.650000e+01'),
-            (F(2, 3), '.6e', '6.666667e-01'),
-            (F(3, 2), '.6e', '1.500000e+00'),
-            # Zero
-            (F(0), '.3e', '0.000e+00'),
-            # Powers of 10, to exercise the log10 boundary logic
-            (F(1, 1000), '.3e', '1.000e-03'),
-            (F(1, 100), '.3e', '1.000e-02'),
-            (F(1, 10), '.3e', '1.000e-01'),
-            (F(1, 1), '.3e', '1.000e+00'),
-            (F(10), '.3e', '1.000e+01'),
-            (F(100), '.3e', '1.000e+02'),
-            (F(1000), '.3e', '1.000e+03'),
-            # Boundary where we round up to the next power of 10
-            (F('99.999994999999'), '.6e', '9.999999e+01'),
-            (F('99.999995'), '.6e', '1.000000e+02'),
-            (F('99.999995000001'), '.6e', '1.000000e+02'),
-            # Negatives
-            (F(-2, 3), '.6e', '-6.666667e-01'),
-            (F(-3, 2), '.6e', '-1.500000e+00'),
-            (F(-100), '.6e', '-1.000000e+02'),
-            # Large and small
-            (F('1e1000'), '.3e', '1.000e+1000'),
-            (F('1e-1000'), '.3e', '1.000e-1000'),
-            # Using 'E' instead of 'e' should give us a capital 'E'
-            (F(2, 3), '.6E', '6.666667E-01'),
-            # Tiny precision
-            (F(2, 3), '.1e', '6.7e-01'),
-            (F('0.995'), '.0e', '1e+00'),
-            # Default precision is 6
-            (F(22, 7), 'e', '3.142857e+00'),
-            # Alternate form forces a decimal point
-            (F('0.995'), '#.0e', '1.e+00'),
-            # Check that padding takes the exponent into account.
-            (F(22, 7), '11.6e', '3.142857e+00'),
-            (F(22, 7), '12.6e', '3.142857e+00'),
-            (F(22, 7), '13.6e', ' 3.142857e+00'),
-            # Legal to specify a thousands separator, but it'll have no effect
-            (F('1234567.123456'), ',.5e', '1.23457e+06'),
-            # Same with z flag: legal, but useless
-            (F(-1, 7**100), 'z.6e', '-3.091690e-85'),
+            (F('0.000012345678'), '.6g', '1.23457e-05'),
+            (F('0.00012345678'), '.6g', '0.000123457'),
+            (F('0.0012345678'), '.6g', '0.00123457'),
+            (F('0.012345678'), '.6g', '0.0123457'),
+            (F('0.12345678'), '.6g', '0.123457'),
+            (F('1.2345678'), '.6g', '1.23457'),
+            (F('12.345678'), '.6g', '12.3457'),
+            (F('123.45678'), '.6g', '123.457'),
+            (F('1234.5678'), '.6g', '1234.57'),
+            (F('12345.678'), '.6g', '12345.7'),
+            (F('123456.78'), '.6g', '123457'),
+            (F('1234567.8'), '.6g', '1.23457e+06'),
+            # Rounding up cases
+            (F('9.99999e+2'), '.4g', '1000'),
+            (F('9.99999e-8'), '.4g', '1e-07'),
+            (F('9.99999e+8'), '.4g', '1e+09'),
+            # Trailing zeros and decimal point suppressed by default ...
+            (F(0), '.6g', '0'),
+            (F('123.400'), '.6g', '123.4'),
+            (F('123.000'), '.6g', '123'),
+            (F('120.000'), '.6g', '120'),
+            (F('12000000'), '.6g', '1.2e+07'),
+            # ... but not when alternate form is in effect
+            (F(0), '#.6g', '0.00000'),
+            (F('123.400'), '#.6g', '123.400'),
+            (F('123.000'), '#.6g', '123.000'),
+            (F('120.000'), '#.6g', '120.000'),
+            (F('12000000'), '#.6g', '1.20000e+07'),
+            # 'G' format (uses 'E' instead of 'e' for the exponent indicator)
+            (F('123.45678'), '.6G', '123.457'),
+            (F('1234567.8'), '.6G', '1.23457E+06'),
+            # Default precision is 6 significant figures
+            (F('3.1415926535'), 'g', '3.14159'),
+            # Precision 0 is treated the same as precision 1.
+            (F('0.000031415'), '.0g', '3e-05'),
+            (F('0.00031415'), '.0g', '0.0003'),
+            (F('0.31415'), '.0g', '0.3'),
+            (F('3.1415'), '.0g', '3'),
+            (F('3.1415'), '#.0g', '3.'),
+            (F('31.415'), '.0g', '3e+01'),
+            (F('31.415'), '#.0g', '3.e+01'),
+            (F('0.000031415'), '.1g', '3e-05'),
+            (F('0.00031415'), '.1g', '0.0003'),
+            (F('0.31415'), '.1g', '0.3'),
+            (F('3.1415'), '.1g', '3'),
+            (F('3.1415'), '#.1g', '3.'),
+            (F('31.415'), '.1g', '3e+01'),
+            # Thousands separator
+            (F(2**64), '_.25g', '18_446_744_073_709_551_616'),
+            # As with 'e' format, z flag is legal, but has no effect
+            (F(-1, 7**100), 'zg', '-3.09169e-85'),
         ]
         for fraction, spec, expected in testcases:
             with self.subTest(fraction=fraction, spec=spec):
@@ -1088,11 +1147,15 @@ class FractionTest(unittest.TestCase):
             ">010f",
             "<010f",
             "^010f",
-            "=010f",
             "=010e",
+            "=010f",
+            "=010g",
+            "=010%",
             # Missing precision
-            ".f",
             ".e",
+            ".f",
+            ".g",
+            ".%",
         ]
         for spec in invalid_specs:
             with self.subTest(spec=spec):

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -976,6 +976,15 @@ class FractionTest(unittest.TestCase):
             # is being inserted programmatically: spec = f'{width}.2f'.
             (F('12.34'), '0.2f', '12.34'),
             (F('12.34'), 'X>0.2f', '12.34'),
+            # z flag for suppressing negative zeros
+            (F('-0.001'), 'z.2f', '0.00'),
+            (F('-0.001'), '-z.2f', '0.00'),
+            (F('-0.001'), '+z.2f', '+0.00'),
+            (F('-0.001'), ' z.2f', ' 0.00'),
+            (F('0.001'), 'z.2f', '0.00'),
+            (F('0.001'), '-z.2f', '0.00'),
+            (F('0.001'), '+z.2f', '+0.00'),
+            (F('0.001'), ' z.2f', ' 0.00'),
             # "F" should work identically to "f"
             (F(22, 7), '.5F', '3.14286'),
             # %-specifier

--- a/Misc/NEWS.d/next/Library/2022-12-10-15-30-17.gh-issue-67790.P9YUZM.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-10-15-30-17.gh-issue-67790.P9YUZM.rst
@@ -1,0 +1,2 @@
+Add float-style formatting support for :class:`fractions.Fraction`
+instances.


### PR DESCRIPTION
This work-in-progress / proof-of-concept PR adds float-style formatting for `fractions.Fraction` objects.

So far this includes support for the 'e', 'f', 'g', and '%' presentation types. The 'n' presentation type is not yet supported.

```python
Python 3.12.0a2+ (heads/fraction-format:8cf8d31ce7, Dec  3 2022, 17:24:40) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from fractions import Fraction as F
>>> f = F(22, 7)
>>> format(f, 'f')
'3.142857'
>>> format(f, 'e')
'3.142857e+00'
>>> f'{f:f}'  
'3.142857'
>>> format(f, '.50f')
'3.14285714285714285714285714285714285714285714285714'
>>> format(F('123456789.12345678'), '_.6f')
'123_456_789.123457'
>>> format(f, '020,f')
'0,000,000,003.142857'
>>> format(f, 'X^20f')
'XXXXXX3.142857XXXXXX'
>>> format(F(2**10000), 'e')
'1.995063e+3010'
```

It supports all reasonable bells and whistles of the formatting mini-language.
