### PR TITLE
gh-67790: Add integer-style formatting for fractions.Fraction

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -106,6 +106,10 @@ another rational number, or from a string.
       presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``, ``"G"``
       and ``"%""``.
 
+   .. versionchanged:: 3.13
+      :class:`Fraction` instances now support integer-style formatting, with
+      presentation type ``"d"`` or missing presentation type.
+
    .. attribute:: numerator
 
       Numerator of the Fraction in lowest term.
@@ -204,10 +208,14 @@ another rational number, or from a string.
       Provides support for float-style formatting of :class:`Fraction`
       instances via the :meth:`str.format` method, the :func:`format` built-in
       function, or :ref:`Formatted string literals <f-strings>`. The
-      presentation types ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``, ``"G"``
-      and ``"%"`` are supported. For these presentation types, formatting for a
-      :class:`Fraction` object ``x`` follows the rules outlined for
-      the :class:`float` type in the :ref:`formatspec` section.
+      presentation types ``"d"``, ``"e"``, ``"E"``, ``"f"``, ``"F"``, ``"g"``,
+      ``"G"`` and ``"%"`` are supported. For presentation types other than
+      ``"d"``, formatting for a :class:`Fraction` object follows the
+      rules outlined for the :class:`float` type in the :ref:`formatspec`
+      section. For presentation type ``"d"``, formatting follows the rules for
+      the :class:`int` type, except that the zero-fill flag is not supported.
+      If no presentation type is given, the rules are identical to those for
+      presentation type ``"d"``.
 
       Here are some examples::
 
@@ -221,7 +229,10 @@ another rational number, or from a string.
          >>> old_price, new_price = 499, 672
          >>> "{:.2%} price increase".format(Fraction(new_price, old_price) - 1)
          '34.67% price increase'
-
+         >>> format(Fraction(103993, 33102), '_d')
+         '103_993/33_102'
+         >>> format(Fraction(1, 7), '.^+10')
+         '...+1/7...'
 
 .. seealso::
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -171,6 +171,13 @@ doctest
   :attr:`doctest.TestResults.skipped` attributes.
   (Contributed by Victor Stinner in :gh:`108794`.)
 
+fractions
+---------
+
+* Objects of type :class:`fractions.Fraction` now support integer-style
+  formatting with the ``d`` presentation type. (Contributed by Mark Dickinson
+  in :gh:`?????`)
+
 io
 --
 

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -848,17 +848,57 @@ class FractionTest(unittest.TestCase):
         self.assertEqual(type(f.numerator), myint)
         self.assertEqual(type(f.denominator), myint)
 
-    def test_format_no_presentation_type(self):
-        # Triples (fraction, specification, expected_result)
+    def test_format_d_presentation_type(self):
+        # Triples (fraction, specification, expected_result). We test both
+        # with and without a trailing 'd' on the specification.
         testcases = [
-            (F(1, 3), '', '1/3'),
-            (F(-1, 3), '', '-1/3'),
-            (F(3), '', '3'),
-            (F(-3), '', '-3'),
+            # Explicit sign handling
+            (F(2, 3), '+', '+2/3'),
+            (F(-2, 3), '+', '-2/3'),
+            (F(3), '+', '+3'),
+            (F(-3), '+', '-3'),
+            (F(2, 3), ' ', ' 2/3'),
+            (F(-2, 3), ' ', '-2/3'),
+            (F(3), ' ', ' 3'),
+            (F(-3), ' ', '-3'),
+            (F(2, 3), '-', '2/3'),
+            (F(-2, 3), '-', '-2/3'),
+            (F(3), '-', '3'),
+            (F(-3), '-', '-3'),
+            # Padding
+            (F(0), '5', '    0'),
+            (F(2, 3), '5', '  2/3'),
+            (F(-2, 3), '5', ' -2/3'),
+            (F(2, 3), '0', '2/3'),
+            (F(2, 3), '1', '2/3'),
+            (F(2, 3), '2', '2/3'),
+            # Alignment
+            (F(2, 3), '<5', '2/3  '),
+            (F(2, 3), '>5', '  2/3'),
+            (F(2, 3), '^5', ' 2/3 '),
+            (F(2, 3), '=5', '  2/3'),
+            (F(-2, 3), '<5', '-2/3 '),
+            (F(-2, 3), '>5', ' -2/3'),
+            (F(-2, 3), '^5', '-2/3 '),
+            (F(-2, 3), '=5', '- 2/3'),
+            # Fill
+            (F(2, 3), 'X>5', 'XX2/3'),
+            (F(-2, 3), '.<5', '-2/3.'),
+            (F(-2, 3), '\n^6', '\n-2/3\n'),
+            # Thousands separators
+            (F(1234, 5679), ',', '1,234/5,679'),
+            (F(-1234, 5679), '_', '-1_234/5_679'),
+            (F(1234567), '_', '1_234_567'),
+            (F(-1234567), ',', '-1,234,567'),
+            # Alternate form forces a slash in the output
+            (F(123), '#', '123/1'),
+            (F(-123), '#', '-123/1'),
+            (F(0), '#', '0/1'),
         ]
         for fraction, spec, expected in testcases:
             with self.subTest(fraction=fraction, spec=spec):
                 self.assertEqual(format(fraction, spec), expected)
+                self.assertEqual(format(fraction, spec + 'd'), expected)
 
     def test_format_e_presentation_type(self):
         # Triples (fraction, specification, expected_result)
@@ -1218,6 +1258,12 @@ class FractionTest(unittest.TestCase):
             '.%',
             # Z instead of z for negative zero suppression
             'Z.2f'
+            # D instead of d for integer-style formatting
+            '10D',
+            # z flag not supported for integer-style formatting
+            'zd',
+            # zero padding not supported for integer-style formatting
+            '05d',
         ]
         for spec in invalid_specs:
             with self.subTest(spec=spec):


### PR DESCRIPTION
This is a proof-of-concept PR that extends python/cpython#100161 to add support for the 'd' presentation type in `fractions.Fraction.__format__`.

## Detailed changes

- Add `'d'` presentation type, supporting alignment, fill, sign and minimum width in the obvious-ish way (minimum width applies to the whole formatted number).
- Add support for `#` alternate formatting, which always includes a slash and denominator (by default, if the denominator is `1` then the slash and denominator are left out).
- Include support for thousands separators, with the separator applied to both numerator and denominator separately.
- Do _not_ support zero padding, since it's not clear exactly how that would work or what the use-cases are.
- Make `'d'` the default presentation type: a missing presentation type behaves identically to `'d'`.

Feature complete and tested, but not yet ready to merge - it still needs doc updates.

## To do

- [x] Update what's new entry
- [x] Update docs
- [x] Update news entry (or create a new one if there's been a release since merge of #100161)