### PR TITLE
add test for long addition with over allocation

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1601,5 +1601,12 @@ class LongTest(unittest.TestCase):
                 self.assertEqual(n**2,
                     (1 << (2 * bitlen)) - (1 << (bitlen + 1)) + 1)
 
+    def test_long_add_overallocate(self):
+        # see gh-100688
+        x = (MASK//2) * (MASK+1)
+        x2 = (MASK//2 + 1) * (MASK+1)
+        z = x + x2
+        self.assertEqual(x + x2, MASK * (MASK + 1))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@mdickinson This adds a test case for https://github.com/python/cpython/pull/100688 where there is an over allocation. I manually checked (by adding a print statement) that the rare path of an over-allocation is indeed triggered, but see no clear method of enforcing this in the test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
